### PR TITLE
feat: update environment name to use `review-` prefix

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -8347,7 +8347,7 @@ async function run() {
             deployment = await octokit.rest.repos.listDeployments({
                 ...context.repo,
                 ref: "refs/heads/" + ref,
-                environment: productName || "unknown",
+                environment: `review-${productName || "unknown"}`,
             });
             if (deployment.data.length === 0) {
                 throw new Error("No deployment found");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "action-ephemeral-delete",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "main": "dist/index.js",
   "repository": "git@github.com:Updater/action-ephemeral-delete.git",
   "author": "apollorion <joey@apollorion.com>",

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ async function run() {
             deployment = await octokit.rest.repos.listDeployments({
               ...context.repo,
               ref: "refs/heads/" + ref,
-              environment: productName || "unknown",
+              environment: `review-${productName || "unknown"}`,
             });
 
             if (deployment.data.length === 0) {


### PR DESCRIPTION
Following @colinrymer's input we are clarifying our environment names by prefixing them with `review-`

Related to: https://github.com/Updater/action-ephemeral-create-update/pull/26